### PR TITLE
x/review/git-codereview: Set git config commit.gpgsign to false

### DIFF
--- a/git-codereview/util_test.go
+++ b/git-codereview/util_test.go
@@ -200,6 +200,7 @@ func newGitTest(t *testing.T) (gt *gitTest) {
 		write(t, client+"/.git/hooks/"+h, "#!/bin/sh\nexit 0\n", 0755)
 	}
 
+	trun(t, client, "git", "config", "commit.gpgsign", "false")
 	trun(t, client, "git", "config", "core.editor", "false")
 	pwd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
Otherwise if commit.gpgsign is true in ~/.gitconfig, the following error occurs:

error: There was a problem with the editor 'false'. Please supply the message using either -m or -F option.

Fixes #67402